### PR TITLE
Upgrade to Pyth 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug that prevented lists from being used in events
 - Bug that prevented users from importing accounts from other files
 - Conditionally generate Pyth import (#93)
+- Upgrade to Pyth 0.8.0 to fix dependencies
 
 ## [0.2.7]
 

--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -209,7 +209,7 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             let mut pyth = InlineTable::new();
             pyth.insert(
                 "version",
-                Value::String(Formatted::new("0.7.1".to_string())),
+                Value::String(Formatted::new("0.8.0".to_string())),
             );
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));


### PR DESCRIPTION
This is causing `seahorse build` to fail for newly initialised projects
The previous version of Pyth conflicts with recent Anchor releases
The latest version is 0.8.0 and works correctly 

- No code changes, just fixes the dependency clash
- Also added a simple pyth example to the repo