### PR TITLE
`seahorse build` displays an error despite successful compilation

### DIFF
--- a/src/bin/cli/build.rs
+++ b/src/bin/cli/build.rs
@@ -100,9 +100,13 @@ fn build_program(project_path: &PathBuf, program_name: String) -> Result<String,
 
             let anchor_output = Command::new("anchor").args(args).output()?;
             let stderr = String::from_utf8(anchor_output.stderr)?;
+            let filtered_stderr = stderr.lines()
+                .filter(|line| !line.trim().starts_with("Compiling"))
+                .collect::<Vec<_>>()
+                .join("\n");
 
             if !anchor_output.status.success()
-                || stderr.contains("error") | stderr.contains("panicked")
+                || filtered_stderr.contains("error") | filtered_stderr.contains("panicked")
             {
                 let report_note = concat!(
                     "This is most likely a bug in the Seahorse compiler!\n\n",


### PR DESCRIPTION
# Problem

When you create a new Seahorse project and build it for the first time, it will show that compilation has failed (`This is most likely a bug in the Seahorse compiler! [...]`)

If you run it again, the error message is no longer displayed and it says the project was successfully compiled.

Since `target/deploy/program.so` exists, it was actually successfully compiled.

# Cause

In `src/bin/cli/build.rs`, there is a check to determine whether to show the message:
```
if !anchor_output.status.success()  || stderr.contains("error") | stderr.contains("panicked")
```

The assumption was probably that Anchor only sends warnings and errors to stderr. Unfortunately, this is not the case. Everything is sent to stderr, including `Compiling` statements.

This means that outputs like `Compiling thiserror v1.0.51` are matched, which causes the error message to be displayed.

# Solution

Create a filtered version of `stderr` where all `Compiling` statements are removed and perform the check on that.

# Alternative

The cleanest solution would be to use `if !anchor_output.status.success()` as the only check -- but I'm not sure how reliable the exit code of `anchor build` is.