### PR TITLE
Upgrade to Anchor `0.29.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug that prevented users from importing accounts from other files
 - Conditionally generate Pyth import (#93)
 - Upgrade to Pyth 0.8.0 to fix dependencies
+- Compatibility with `anchor-lang 0.29.0`
 
 ## [0.2.7]
 

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -1358,7 +1358,6 @@ fn make_lib(
 
             let load_accounts = ix_context.accounts.iter().filter_map(
                 |(name, ContextAccount { account_ty, ty, .. })| {
-                    let name_str = name;
                     let name = ident(name);
 
                     // Deconstruct `Empty` accounts
@@ -1400,7 +1399,7 @@ fn make_lib(
                         quote! {
                             let #name = Empty {
                                 account: #loaded,
-                                bump: ctx.bumps.get(#name_str).map(|bump| *bump)
+                                bump: Some(ctx.bumps.#name)
                             };
                         }
                     } else {


### PR DESCRIPTION
### Problem

Seahorse currently doesn't work with latest version of Anchor(`0.29.0`) because of the breaking change with the bumps.

Running the default Seahorse example in [Playground](https://beta.solpg.io/659038a4dc53c576016a1dd2) results with the following error:

```
error[E0599]: no method named `get` found for struct `InitBumps` in the current scope
 --> src/lib.rs:6:5939
  |
6 | ...e (Accounts)] pub struct Init < 'info > { # [account (mut)] pub owner : Signer < 'info > , # [account (init , space = std :: mem :: size_of :: < dot :: program :: FizzBuzz > () + 8 , payer = owner , seeds = ["fizzbuzz" . as_bytes () . as_ref () , owner . key () . as_ref ()] , bump)] pub fizzbuzz : Box < Account < 'info , dot :: program :: FizzBuzz >> , pub rent : Sysvar < 'info , Rent > , pub system_program : Program < 'info , System > } pub fn init (ctx : Context < Init > ,) -> Result < () > { let mut programs = HashMap :: new () ; programs . insert ("system_program" , ctx . accounts . system_program . to_account_info ()) ; let programs_map = ProgramsMap (programs) ; let owner = SeahorseSigner { account : & ctx . accounts . owner , programs : & programs_map } ; let fizzbuzz = Empty { account : dot :: program :: FizzBuzz :: load (& mut ctx . accounts . fizzbuzz , & programs_map) , bump : ctx . bumps . get ("fizzbuzz")
```

### Summary of changes

Update the bumps getters to make it compatible with `anchor-lang 0.29.0`.