### PR TITLE
Fix conflict version when Create new project

### DIFF
--- a/data/const/seahorse_pyth.py
+++ b/data/const/seahorse_pyth.py
@@ -14,7 +14,7 @@ class Price:
     """
     Pyth `Price` struct with some extra convenience functions. You can access the raw data of the struct through its fields.
 
-    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.7.1/pyth_sdk_solana/struct.Price.html)
+    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.10.1/pyth_sdk_solana/struct.Price.html)
     """
 
     price: i64
@@ -30,7 +30,7 @@ class PriceFeed:
     """
     Pyth `PriceFeed` struct with some extra convience functions.
 
-    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.7.1/pyth_sdk_solana/struct.PriceFeed.html)
+    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.10.1/pyth_sdk_solana/struct.PriceFeed.html)
     """
 
     def get_price(self) -> Price:

--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -206,13 +206,16 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             cargo["dependencies"]["anchor-lang"] = anchor_version.clone();
             cargo["dependencies"]["anchor-spl"] = anchor_version;
 
+
             let mut pyth = InlineTable::new();
             pyth.insert(
                 "version",
-                Value::String(Formatted::new("0.7.1".to_string())),
+                Value::String(Formatted::new("0.10.1".to_string())),
             );
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));
+            // Add spl-associated-token-account as a dependency
+            cargo["dependencies"]["spl-associated-token-account"] = Item::Value(Value::String(Formatted::new("2.3.1".to_string())));
 
             File::create(&cargo_path)?.write_all(cargo.to_string().as_bytes())?;
 


### PR DESCRIPTION
# Description
I have checked and discovered that the issue lies in the `[dependencies]` section, where a library is missing. Additionally, one of the libraries is using an outdated version.

Before: 

```
[dependencies]
anchor-lang = "0.29.0"
anchor-spl = "0.29.0"
pyth-sdk-solana = { version = "0.7.0", optional = true }
```

After
```
[dependencies]
anchor-lang = "0.29.0"
anchor-spl = "0.29.0"
spl-associated-token-account = "2.3.1"
pyth-sdk-solana = { version = "0.10.1", optional = true }
```

## Test result
![image](https://github.com/ameliatastic/seahorse-lang/assets/5876946/dfb0db4e-681f-40a2-a618-7049bb57b88d)


## Related issue:
- #17